### PR TITLE
Include elegant exit on main splash

### DIFF
--- a/core/Core/inputin.py
+++ b/core/Core/inputin.py
@@ -20,6 +20,11 @@ def inputin():
     try:
         global web
         web = raw_input(''+O+' [#] Target web address :> '+C)
+        if 'exit' in web:
+            print(R+' [-] Exiting...')
+            time.sleep(0.7)
+            print(C+' [#] Alvida, my friend!')
+            sys.exit(1)
         if not str(web).startswith('http'):
             mo = raw_input(GR+' [#] Does this website use SSL? (y/n) :> ')
             if mo == 'y' or mo == 'Y':


### PR DESCRIPTION
This is an initial pull request for establishing workflow & github familiarization. 

This simple addition allows elegant exit out of TIDoS by typing 'exit' instead of only forcing out of it via Ctrl + C

Note: When first initiating the pull request, the Base (what the branch you worked on will be merged into) defaulted to the unforked TIDoS-Framework, and when I switched the base to the forked repo (what we want), it then defaulted to the "master" branch instead of "cyber-dev-main".   Almost missed that!
